### PR TITLE
feat: Añadir análisis de Arcanum Ilimitado a la bóveda

### DIFF
--- a/Cosmere/00_Meta/_registro_de_analisis.log
+++ b/Cosmere/00_Meta/_registro_de_analisis.log
@@ -1,2 +1,3 @@
 /Users/diegoesqui/Documents/Proyecto Cosmere IA/Cosmere/0_A_Analizar/1_El camino de los reyes - Brandon Sanderson.txt - Lun 18 aoû 2025 13:26:21 CEST
 /Users/diegoesqui/Documents/Proyecto Cosmere IA/Cosmere/0_A_Analizar/2_Palabras radiantes - Brandon Sanderson.txt - Mer 20 aoû 2025 15:30:00 CEST
+Pasted_Text_Arcanum_Ilimitado.txt - Jue 21 ago 2025 07:44:53 CEST

--- a/Cosmere/10_Mundos/Elantris.md
+++ b/Cosmere/10_Mundos/Elantris.md
@@ -1,0 +1,20 @@
+---
+tags: lugar, ciudad, Sel
+---
+
+# Elantris
+
+## Descripción
+Elantris es una ciudad ubicada en el país de Arelon, en el planeta de [[Sel]]. Antiguamente, era la ciudad de los dioses, habitada por los Elantrinos, seres de piel plateada que podían usar el [[AonDor]]. Tras un cataclismo conocido como la Reod, la magia de Elantris falló y la ciudad cayó en la decadencia, convirtiéndose en una prisión para aquellos afectados por la [[Shaod]].
+
+## Eventos Clave
+*   **La Reod:** Un cataclismo que rompió la conexión de Elantris con el [[Dor]], convirtiendo a sus habitantes en seres malditos y doloridos.
+*   **Restauración:** La ciudad y su magia fueron restauradas por el príncipe [[Raoden]].
+*   **Ataque Fjordell:** Como se narra en "La esperanza de Elantris", la ciudad fue atacada por soldados de Fjordell poco después de su restauración.
+
+## Zonas Notables
+*   **Nueva Elantris:** Un asentamiento organizado dentro de las ruinas de Elantris por [[Raoden]] para dar cobijo y orden a los elantrinos caídos.
+
+## Apariciones
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/10_Mundos/Primero_del_Sol.md
+++ b/Cosmere/10_Mundos/Primero_del_Sol.md
@@ -1,0 +1,20 @@
+---
+tags: mundo
+alias: [First of the Sun]
+---
+
+# Primero del Sol
+
+## Descripción
+Primero del Sol es el planeta principal del sistema Drominad. Es un mundo con una alta proporción de agua, compuesto por numerosos archipiélagos.
+
+## Fenómenos
+Lo más notable de Primero del Sol es que posee una [[Perpendicularidad]] a pesar de no tener ninguna [[Esquirlas de Adonalsium|Esquirla]] residiendo en el planeta. Khriss especula que esto se debe a algún evento del pasado. La perpendicularidad se encuentra en una zona extremadamente peligrosa.
+
+El planeta es el hogar de una fauna y flora muy particulares, incluyendo:
+*   Los [[Aviar]]: Aves que, tras comer un tipo específico de gusano parásito de la isla de Patji, obtienen habilidades mágicas que pueden compartir con los humanos.
+*   Una megafauna peligrosa tanto en tierra como en el océano.
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Sexto del Ocaso]]

--- a/Cosmere/10_Mundos/Scadrial.md
+++ b/Cosmere/10_Mundos/Scadrial.md
@@ -1,0 +1,32 @@
+---
+tags: mundo
+alias: []
+---
+
+# Scadrial
+
+## Descripción
+Scadrial es un planeta biesquirlado en el [[Cosmere]], creado desde cero por las Esquirlas [[Ruina]] y [[Conservación]]. Es uno de los pocos lugares donde la humanidad no es nativa, sino que fue creada por las propias Esquirlas a imagen de la humanidad de Yolen.
+
+El planeta ha sufrido cataclismos y transformaciones masivas a lo largo de su historia, incluyendo el desplazamiento de su órbita en varias ocasiones debido al uso de grandes cantidades de [[Investidura]]. A pesar de esto, ha desarrollado una sociedad tecnológicamente avanzada.
+
+## Geografía
+La geografía de Scadrial ha cambiado drásticamente entre sus diferentes eras, desde el mundo cubierto de cenizas del Imperio Final hasta su configuración actual.
+
+## Esquirlas
+* [[Ruina]]
+* [[Conservación]]
+* [[Armonía]] (posteriormente)
+
+## Magia
+Scadrial es el hogar de los tres Artes Metálicos:
+* [[Alomancia]]
+* [[Feruquimia]]
+* [[Hemalurgia]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Nacidos de la bruma: Historia Secreta]]
+* [[El undécimo metal]]
+* Trilogía original de Nacidos de la Bruma
+* Serie de Wax y Wayne

--- a/Cosmere/10_Mundos/Sel.md
+++ b/Cosmere/10_Mundos/Sel.md
@@ -1,0 +1,25 @@
+---
+tags: mundo
+alias: [Mundo Selish]
+---
+
+# Sel
+
+## Descripción
+Sel es un planeta biesquirlado, notable por ser el hogar original de dos [[Esquirlas de Adonalsium|Fragmentos]]: [[Dominio]] y [[Devoción]]. Es más grande que el estándar del Cosmere, con un tamaño de aproximadamente 1.5 veces y una gravedad de 1.2 veces el estándar. Sus continentes y océanos son vastos, generando una gran diversidad de territorios.
+
+La magia en Sel tiene una fuerte dependencia de la ubicación física y el lenguaje. Esto se debe a que la Investidura del planeta, conocida colectivamente como el [[Dor]], está atrapada en el Reino Cognitivo. Khriss especula que el propio territorio ha sido Investido hasta el punto de tener una creciente consciencia de sí mismo.
+
+## Reinos y Naciones
+El planeta alberga varios imperios, cada uno de los cuales tiende a ignorar deliberadamente a los demás. Los tres grandes dominios son los más destacados.
+
+## Esquirlas
+* [[Dominio]]
+* [[Devoción]]
+
+Ambas Esquirlas fueron destruidas (Astilladas) en el pasado lejano. Su poder, sin embargo, permanece.
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Elantris]]
+* [[El alma del emperador]]

--- a/Cosmere/10_Mundos/Taldain.md
+++ b/Cosmere/10_Mundos/Taldain.md
@@ -1,0 +1,25 @@
+---
+tags: mundo
+alias: []
+---
+
+# Taldain
+
+## Descripción
+Taldain es un planeta con acoplamiento de marea, atrapado en un sistema binario de estrellas. Esta configuración divide el planeta en dos caras con ecosistemas y culturas radicalmente diferentes: el Lado Diurno y el Lado Oscuro.
+
+Actualmente, el planeta está bajo una estricta política de aislacionismo impuesta por su Esquirla, [[Autonomía]].
+
+## Geografía
+*   **Lado Diurno:** Una cara del planeta que está perpetuamente iluminada por una estrella supergigante blanquiazul. Es un vasto desierto de arena blanca. La vida se desarrolla principalmente bajo la superficie para escapar del calor constante. La [[Investidura]] de la Esquirla desciende desde el sol y es absorbida por una microflora en la arena.
+*   **Lado Oscuro:** La otra cara del planeta, en un crepúsculo perpetuo, iluminada solo por la luz ultravioleta de una débil enana blanca. La flora y fauna de este lado son a menudo bioluminiscentes.
+
+## Esquirla
+* [[Autonomía]]
+
+## Magia
+* [[Maestria_de_Arena]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Arena blanca]]

--- a/Cosmere/10_Mundos/Treno.md
+++ b/Cosmere/10_Mundos/Treno.md
@@ -1,0 +1,22 @@
+---
+tags: mundo
+alias: [Threnody]
+---
+
+# Treno
+
+## Descripción
+Treno es un planeta del [[Cosmere]] marcado por un antiguo y violento conflicto entre las [[Esquirlas de Adonalsium|Esquirlas]] [[Odium]] y [[Ambición]]. Aunque la batalla principal ocurrió en el espacio, las ondas de choque de poder alteraron profundamente el planeta y a sus habitantes.
+
+## Geografía
+El planeta tiene dos continentes principales:
+*   **El Mundo Caído (Patria):** El continente más grande, que fue completamente consumido y abandonado a una fuerza conocida como [[La Maldad]].
+*   **El Continente Fronterizo:** Un continente más pequeño y sin nombre donde viven los descendientes de los refugiados que huyeron del Mundo Caído. La historia "Sombras por Silencio en los bosques del infierno" tiene lugar aquí.
+
+## Fenómenos
+*   **[[Sombras Cognitivas]]:** Las personas en Treno a veces persisten después de la muerte como [[Sombras Cognitivas]], conocidas por los locales como "umbras" o fantasmas. Se sienten atraídas por la sangre, el fuego y los movimientos bruscos.
+*   **La Maldad:** Una fuerza oscura y misteriosa que domina el continente principal.
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Sombras por Silencio en los bosques del infierno]]

--- a/Cosmere/20_Personajes/Por_Mundo/Primero_del_Sol/Sexto_del_Ocaso.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Primero_del_Sol/Sexto_del_Ocaso.md
@@ -1,0 +1,27 @@
+---
+tags: personaje, Primero del Sol
+alias: [Ocaso]
+---
+
+# Sexto del Ocaso
+
+## Resumen
+Sexto del Ocaso, o simplemente Ocaso, es un trampero del pueblo Eelakin que trabaja en la peligrosa isla de Patji, en el planeta [[Primero del Sol]]. Es el protagonista de la historia que lleva su nombre.
+
+## Apariencia y Personalidad
+Ocaso es un hombre solitario, competente y profundamente conectado con las tradiciones de su pueblo y los peligros de su isla. Es observador, prefiere el silencio a la conversación y es un superviviente nato. Su nombre le fue dado por su madre, que veía en él el "ocaso" o fin de su modo de vida tradicional.
+
+## Habilidades
+Ocaso es un experto trampero y superviviente. Posee dos [[Aviar]]:
+*   **Kokerlii:** Un aviar que puede proteger su mente de la detección por parte de los depredadores psíquicos de la isla.
+*   **Sak:** Un ave única, no nativa de las islas, que obtuvo un talento especial en Patji. Puede mostrarle a Ocaso visiones de su propia muerte para advertirle de peligros inmediatos.
+
+## Historia
+La historia sigue a Ocaso en una de sus expediciones a Patji. Se encuentra con Vathi, una mujer de una compañía comercial que busca explotar los secretos de los Aviar. Juntos, se enfrentan a los peligros de la isla, como las quijanoches, y descubren una amenaza mayor: los "Venídos de Arriba" (viajeros interplanetarios) que buscan manipular a su civilización para sus propios fines. Al final, Ocaso decide ayudar a Vathi a proteger a su pueblo de esta nueva amenaza.
+
+## Conexiones Relevantes
+* **Aviar:** Kokerlii, Sak
+* **Compañera:** Vathi
+
+## Apariciones
+* [[Sexto del Ocaso]]

--- a/Cosmere/20_Personajes/Por_Mundo/Roshar/Lift.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Roshar/Lift.md
@@ -22,9 +22,13 @@ Su spren, [[Wyndle]], la ayuda a desarrollar sus poderes. También tiene la habi
 ### Sucesos en 'Palabras radiantes'
 Lift aparece en un interludio, donde se infiltra en el Palacio de Bronce de Azir para robar la cena del Supremo. Se enfrenta a [[Oscuridad]] (Nalan), quien intenta matarla. Es salvada por la intervención de [[Gawx]], quien se convierte en el nuevo Supremo y le concede el perdón.
 
+### Sucesos en 'Danzante del Filo'
+Después de abandonar Azir, Lift viaja a la ciudad de Yeddaw. Allí, persigue a [[Oscuridad]] para detenerlo de asesinar a otros potenciadores emergentes. Descubre que una mujer llamada "la Tocón" también es una [[Danzantes del Filo|Danzante del Filo]]. Durante una confrontación con [[Oscuridad]] en medio de la llegada de la [[Tormenta Eterna]], Lift pronuncia el Tercer Ideal de los Danzantes del Filo ("¡Escucharé a aquellos que han sido ignorados!") y usa su comprensión para "escuchar" el dolor de Nalan, ayudándolo a confrontar su propio fracaso y salvándolo en lugar de luchar contra él.
+
 ## Conexiones Relevantes
 * **Spren:** [[Wyndle]].
-* **Enemigos:** [[Oscuridad]].
+* **Enemigos:** [[Oscuridad]] (aunque su relación se vuelve más compleja).
 
 ## Apariciones
 * [[Palabras radiantes]]
+* [[Danzante del Filo]]

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Alomante_Jak.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Alomante_Jak.md
@@ -1,0 +1,22 @@
+---
+tags: personaje, Scadrial
+alias: [Jak]
+---
+
+# Alomante Jak
+
+## Resumen
+Jak es un aventurero y Alomante que vive en los Áridos de [[Scadrial]] durante la era de Wax y Wayne. Sus hazañas se publican en formato de folletín en los periódicos de Elendel, anotadas por su mayordomo terrisano, [[Handerwym]].
+
+## Apariencia y Personalidad
+En sus propios relatos, Jak se presenta como un caballero intrépido, un maestro de la pistola y un aventurero heroico y galante. Sin embargo, las anotaciones de [[Handerwym]] sugieren que es un fanfarrón, a menudo incompetente, propenso a la exageración y con un intelecto cuestionable.
+
+## Habilidades e Investidura
+Jak es un [[Alomancia|Alomante]], aunque la extensión y destreza de sus habilidades son a menudo exageradas en sus relatos.
+
+## Conexiones Relevantes
+* **Mayordomo:** [[Handerwym]]
+* **Interés amoroso:** [[Elizandra Dramali]]
+
+## Apariciones
+* [[Alomante Jak y los Pozos de Eltania]]

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Elend_Venture.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Elend_Venture.md
@@ -1,0 +1,26 @@
+---
+tags: personaje, Scadrial
+alias: [Emperador Elend]
+---
+
+# Elend Venture
+
+## Resumen
+Elend Venture era el hijo noble y erudito de Straff Venture, la cabeza de la casa más poderosa de Luthadel. Inicialmente un idealista que criticaba en secreto al régimen, se convirtió en el rey y posterior emperador del Nuevo Imperio tras la caída del lord Legislador.
+
+## Apariencia y Personalidad
+Es descrito como un hombre alto y de cabello rubio claro. Al principio de la saga, es un hombre estudioso, filosófico y a menudo indeciso, más interesado en los libros que en la política. Con el tiempo, y bajo la influencia de [[Vin]], se convierte en un líder fuerte, pragmático y decidido, aunque siempre se guía por sus ideales de justicia y un gobierno justo.
+
+## Habilidades e Investidura
+Originalmente, Elend no era un Alomante. Sin embargo, tras ser herido de muerte, [[Vin]] le salva la vida haciendo que ingiera una perla de lerasium del [[Pozo de la Ascensión]], lo que lo convierte en un Nacido de la Bruma extremadamente poderoso.
+
+## Historia
+Elend lidera al Nuevo Imperio durante los asedios a Luthadel y la guerra contra las fuerzas de [[Ruina]]. Lucha y muere en la batalla final en los Pozos de Hathsin. En "Nacidos de la bruma: Historia Secreta", su espíritu se encuentra brevemente con el de [[Kelsier]] en el [[Reino Cognitivo]] antes de partir al Más Allá con [[Vin]].
+
+## Conexiones Relevantes
+* **Esposa:** [[Vin]]
+* **Padre:** Straff Venture
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Elizandra_Dramali.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Elizandra_Dramali.md
@@ -1,0 +1,21 @@
+---
+tags: personaje, Scadrial, Sangre-Koloss
+alias: [Zandra]
+---
+
+# Elizandra Dramali
+
+## Resumen
+Elizandra Dramali es el principal interés amoroso de [[Alomante Jak]] en sus aventuras por los Áridos. Aunque inicialmente se presenta como una dama noble, se revela que en realidad tiene sangre [[Koloss]].
+
+## Apariencia y Personalidad
+Jak la describe como una mujer hermosa, con cabello dorado. Es inteligente e ingeniosa, y a menudo se muestra exasperada por las payasadas de Jak, aunque sus acciones demuestran que le tiene cariño. Usa maquillaje para ocultar el ligero tono azulado de su piel, característico de su herencia.
+
+## Historia
+En "Alomante Jak y los Pozos de Eltania", Elizandra guía a Jak hacia su tribu koloss. Se revela que su madre era la campeona de la tribu, a quien Jak había derrotado. Se opone firmemente a la idea de que Jak (o ella misma) se someta a la transformación para convertirse en un koloss completo y ayuda a Jak a escapar pasándole estaño durante un beso para que pueda recuperar el Tesoro del Superviviente.
+
+## Conexiones Relevantes
+* **Interés amoroso:** [[Alomante Jak]]
+
+## Apariciones
+* [[Alomante Jak y los Pozos de Eltania]]

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Gemmel.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Gemmel.md
@@ -1,0 +1,20 @@
+---
+tags: personaje, Scadrial
+---
+
+# Gemmel
+
+## Resumen
+Gemmel es un viejo y excéntrico Nacido de la Bruma que se convierte en el maestro de [[Kelsier]] después de que este escapara de los Pozos de Hathsin.
+
+## Apariencia y Personalidad
+Es un hombre mayor, desaliñado, con una barba raída y entrecana. Su comportamiento es errático y parece estar al borde de la locura, a menudo murmurando para sí mismo. Su método de enseñanza es brutal y directo, forzando a [[Kelsier]] a aprender a luchar como un Nacido de la Bruma a través de situaciones de vida o muerte.
+
+## Historia
+Gemmel entrena a [[Kelsier]] en el uso de los Artes Metálicos para el combate, despreciando el uso de la alomancia emocional que Kelsier prefiere. Guía a Kelsier hasta la ciudad de Mantiz para que se enfrente a lord Shezler, otro Nacido de la Bruma, como parte de su entrenamiento.
+
+## Conexiones Relevantes
+* **Aprendiz:** [[Kelsier]]
+
+## Apariciones
+* [[El undécimo metal]]

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Handerwym.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Handerwym.md
@@ -1,0 +1,20 @@
+---
+tags: personaje, Scadrial, Terris
+---
+
+# Handerwym
+
+## Resumen
+Handerwym es el mayordomo terrisano de [[Alomante Jak]]. Cumple la función de editor y anotador de las aventuras de Jak, que se publican en los periódicos de Elendel.
+
+## Apariencia y Personalidad
+Handerwym es un individuo erudito, paciente (aunque frecuentemente exasperado por su empleador) y posee un humor muy seco. Sus anotaciones a pie de página son una fuente constante de correcciones, aclaraciones y comentarios sarcásticos sobre las exageraciones y omisiones de Jak. A través de sus notas, se revela como una persona inteligente y observadora que a menudo intenta (sin mucho éxito) explicar conceptos del [[Cosmere]] a Jak.
+
+## Historia
+Acompaña a Jak en sus viajes por los Áridos. Como mayordomo terrisano, ha hecho un juramento de pacifismo. Su principal labor es documentar las "aventuras" de Jak para su publicación.
+
+## Conexiones Relevantes
+* **Empleador:** [[Alomante Jak]]
+
+## Apariciones
+* [[Alomante Jak y los Pozos de Eltania]]

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Kelsier.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Kelsier.md
@@ -1,0 +1,33 @@
+---
+tags: personaje, Scadrial
+alias: [el Superviviente de Hathsin, Kell]
+---
+
+# Kelsier
+
+## Resumen
+Kelsier, conocido como el Superviviente de Hathsin, es un legendario Nacido de la Bruma de sangre mestiza. Es famoso por haber liderado la rebelión skaa que derrocó al lord Legislador y al Imperio Final.
+
+## Apariencia y Personalidad
+Kelsier es carismático, optimista y a menudo se le describe con una sonrisa desafiante. Su personalidad alegre oculta un profundo odio hacia la nobleza y el lord Legislador, así como un trauma por su tiempo en los Pozos de Hathsin y la muerte de su esposa, Mare. Es un líder nato y un maestro de la planificación y la manipulación.
+
+## Habilidades e Investidura
+Kelsier es un Nacido de la Bruma excepcionalmente poderoso y hábil, capaz de usar todos los metales alománticos con gran destreza.
+
+## Historia
+La historia "El undécimo metal" detalla parte de su entrenamiento con su maestro, [[Gemmel]], poco después de escapar de los Pozos de Hathsin. Durante este tiempo, se enfrenta a su primer Nacido de la Bruma enemigo y comienza a concebir su plan para derrocar al Imperio Final.
+
+"Nacidos de la bruma: Historia Secreta" narra los eventos posteriores a su muerte a manos del lord Legislador. En lugar de pasar al Más Allá, su espíritu queda atrapado en el [[Reino Cognitivo]]. Allí se encuentra con [[Conservacion]] (a quien apoda "Borrón") y se entera del conflicto más amplio con [[Ruina]].
+
+Para evitar desaparecer, se ancla al [[Pozo de la Ascensión]]. Desde allí, observa e intenta influir en sus amigos, especialmente en [[Vin]]. Tras la liberación de [[Ruina]], Kelsier viaja por el Reino Cognitivo, se encuentra con los [[Ire]] y finalmente toma brevemente el poder de [[Conservacion]] para ayudar en la derrota de Ruina. Al final, se une a [[Fantasma]] para explorar los misterios del [[Cosmere]].
+
+## Conexiones Relevantes
+* **Maestro:** [[Gemmel]]
+* **Hermano:** [[Marsh]]
+* **Protegida:** [[Vin]]
+* **Esposa:** Mare
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[El undécimo metal]]
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Marsh.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Marsh.md
@@ -1,0 +1,26 @@
+---
+tags: personaje, Scadrial
+alias: [Ojos de Hierro]
+---
+
+# Marsh
+
+## Resumen
+Marsh es el hermano mayor de [[Kelsier]]. Originalmente fue el líder de la rebelión skaa antes de que Kelsier se hiciera cargo. Es capturado por el lord Legislador y transformado a la fuerza en un [[Inquisidor de Acero]].
+
+## Apariencia y Personalidad
+Antes de su transformación, Marsh era un hombre serio, pesimista y cauteloso, a menudo en conflicto con el carácter temerario de su hermano. Como Inquisidor, su personalidad es en gran medida suprimida y controlada por [[Ruina]] a través de sus clavos hemalúrgicos.
+
+## Habilidades e Investidura
+Originalmente, Marsh era un Buscador (un brumoso de bronce). Como Inquisidor de Acero, la [[Hemalurgia]] le otorga los poderes de un Nacido de la Bruma y la [[Feruquimia]] de un Guardador.
+
+## Historia
+Tras ser convertido en Inquisidor, Marsh sirve al lord Legislador y, posteriormente, a [[Ruina]]. A pesar de estar bajo el control casi total de Ruina, es capaz de luchar contra su influencia en momentos clave. En el clímax de la trilogía original, logra liberarse del control de Ruina el tiempo suficiente para arrancarle el pendiente a [[Vin]], un acto que permite a Vin derrotar a Ruina.
+
+## Conexiones Relevantes
+* **Hermano:** [[Kelsier]]
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]
+* Serie de Wax y Wayne

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Sazed.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Sazed.md
@@ -1,0 +1,28 @@
+---
+tags: personaje, Scadrial, Terris, esquirla
+alias: [Armonía]
+---
+
+# Sazed
+
+## Resumen
+Sazed es un mayordomo terrisano y un Guardador Feruquimista. Como Guardador, su deber es memorizar y preservar el conocimiento de las religiones que fueron suprimidas por el lord Legislador. Es un amigo y consejero leal de la banda de [[Kelsier]].
+
+## Apariencia y Personalidad
+Es calvo, como es costumbre entre los mayordomos terrisanos. Es un hombre erudito, sabio, educado y compasivo. Durante los eventos de la trilogía original, sufre una profunda crisis de fe tras la muerte de su amada, la también Guardadora Tindwyl.
+
+## Habilidades e Investidura
+Sazed es un [[Feruquimia|Feruquimista]] muy hábil, capaz de usar todos los metales para almacenar una amplia gama de atributos.
+
+## Historia
+Tras la muerte de [[Vin]] y [[Elend Venture]], Sazed se encuentra en el lugar donde los poderes de [[Conservación]] y [[Ruina]] han sido liberados. Al ser un terrisano (con afinidad tanto por la Ruina como por la Conservación) y comprender ambas intenciones, es capaz de tomar las dos Esquirlas simultáneamente.
+
+Al hacerlo, Asciende y se convierte en una nueva entidad dual conocida como [[Armonía]]. Usa su nuevo poder para reparar el planeta [[Scadrial]], moviendo el sol y restaurando el equilibrio ecológico.
+
+## Conexiones Relevantes
+* **Amigos:** [[Kelsier]], [[Vin]], [[Elend Venture]]
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]
+* Serie de Wax y Wayne (como Armonía)

--- a/Cosmere/20_Personajes/Por_Mundo/Scadrial/Vin.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Scadrial/Vin.md
@@ -1,0 +1,28 @@
+---
+tags: personaje, Scadrial
+alias: [la Heredera del Superviviente]
+---
+
+# Vin
+
+## Resumen
+Vin fue una Nacida de la Bruma de sangre mestiza que pasó su infancia como una ladrona callejera skaa. Fue reclutada por la banda de [[Kelsier]] y se convirtió en una de las Alomantes más poderosas de la historia, jugando un papel fundamental en la caída del Imperio Final y en el posterior conflicto con la Esquirla [[Ruina]].
+
+## Apariencia y Personalidad
+Es una mujer menuda y delgada, con cabello oscuro. Debido a una infancia de abusos y traumas, inicialmente era extremadamente desconfiada y cautelosa. A lo largo de su historia, evoluciona hasta convertirse en una mujer fuerte, decidida y compasiva, aunque siempre luchando con sus inseguridades.
+
+## Habilidades e Investidura
+Vin es una Nacida de la Bruma excepcionalmente poderosa. Demostró un talento natural para la [[Alomancia]] y desarrolló una conexión inusualmente fuerte con las brumas, que eran una manifestación del poder de [[Conservación]].
+
+## Historia
+Tras ser entrenada por [[Kelsier]], Vin fue instrumental en el asesinato del lord Legislador. Posteriormente, se enfrentó a la amenaza de [[Ruina]]. En el clímax del conflicto, absorbió el poder de las brumas y ascendió brevemente como el nuevo Recipiente de [[Conservación]]. Finalmente, se sacrificó junto con [[Elend Venture]] para derrotar a Ruina, permitiendo que [[Sazed]] tomara ambas Esquirlas y se convirtiera en [[Armonía]].
+
+En "Nacidos de la bruma: Historia Secreta", se revela que [[Kelsier]] la observó y trató de guiarla desde el [[Reino Cognitivo]] después de su propia muerte.
+
+## Conexiones Relevantes
+* **Mentor:** [[Kelsier]]
+* **Esposo:** [[Elend Venture]]
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Ashravan.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Ashravan.md
@@ -1,0 +1,21 @@
+---
+tags: personaje, Sel
+alias: [Emperador Ashravan de los Ochenta Soles]
+---
+
+# Ashravan
+
+## Resumen
+Ashravan es el Emperador del Imperio Rosa en [[Sel]]. Al comienzo de "El alma del emperador", sufre un intento de asesinato que lo deja en un estado catatónico, con la mente "borrada". Este suceso desencadena la trama principal, en la que los árbitros contratan a [[Shai]] para crearle una nueva alma mediante la [[Falsificacion]].
+
+## Apariencia y Personalidad
+Antes de su herida, Ashravan era un hombre de unos cuarenta años con cabello dorado. Su personalidad era una mezcla de idealismo y autocomplacencia. En su juventud, deseaba reformar la corrupción del imperio, pero con el tiempo se dejó llevar por la comodidad de su posición. Era un hombre fundamentalmente humilde pero con un temperamento fuerte y un profundo anhelo no realizado de haber sido un mejor líder.
+
+## Historia
+Tras un ataque de asesinos de la Facción Gloria, Ashravan queda con el cerebro dañado. Para evitar que la facción rival tome el poder, los árbitros de su facción, liderados por [[Frava]] y [[Gaotona]], contratan a [[Shai]] para que le cree un alma nueva en 100 días. Al final, Shai no solo logra replicar su alma, sino que introduce cambios sutiles para reforzar sus mejores cualidades, dándole una segunda oportunidad para convertirse en el gran emperador que siempre quiso ser.
+
+## Conexiones Relevantes
+* **Subordinados/Consejeros:** [[Gaotona]], [[Frava]]
+
+## Apariciones
+* [[El alma del emperador]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Dashe.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Dashe.md
@@ -1,0 +1,21 @@
+---
+tags: personaje, Sel
+---
+
+# Dashe
+
+## Resumen
+Dashe es un guerrero elantrino y uno de los líderes militares de Nueva Elantris. Actúa como una figura paterna para [[Matisse]] y los demás niños del orfanato.
+
+## Apariencia y Personalidad
+Es un guerrero adusto y hábil, leal a [[Raoden]] pero a veces crítico con sus decisiones. A pesar de su exterior duro, es protector y cariñoso con los niños, especialmente con [[Matisse]].
+
+## Historia
+En "La esperanza de Elantris", Dashe está entrenando a los elantrinos en el uso de armas cuando la ciudad es atacada por soldados de Fjordell. Lucha valientemente para defender a [[Matisse]] y a los niños mientras escapan. Es asesinado durante el combate, convirtiéndose brevemente en un *hoed*, pero es restaurado a su estado de Elantrino completo cuando [[Raoden]] arregla la magia de [[Elantris]] al final del libro *Elantris*.
+
+## Conexiones Relevantes
+* **Figura Paterna de:** [[Matisse]]
+* **Líder:** [[Raoden]]
+
+## Apariciones
+* [[La esperanza de Elantris]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Frava.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Frava.md
@@ -1,0 +1,22 @@
+---
+tags: personaje, Sel
+alias: [decana Frava]
+---
+
+# Frava
+
+## Resumen
+Frava es la decana de los árbitros de la Facción de la Herencia y una de las figuras políticas más poderosas del Imperio Rosa, solo por debajo del emperador. Es la principal impulsora del plan para forzar a [[Shai]] a Falsificar una nueva alma para el emperador [[Ashravan]].
+
+## Apariencia y Personalidad
+Es una mujer con el cabello canoso recogido en una trenza y una voz nasal e intensa. Se muestra como una líder pragmática y controladora, pero siente un profundo desprecio por la [[Falsificacion]] y por [[Shai]]. Su principal motivación es mantener el poder de su facción y está dispuesta a utilizar cualquier medio para lograrlo.
+
+## Historia
+Frava es quien negocia con [[Shai]] los términos de su "contrato". A lo largo de la historia, intenta manipularla y controlarla. Intenta robar las notas de Shai para que su propio Falsificador, menos hábil pero más leal, termine el trabajo, con la intención de ejecutar a Shai en cuanto deje de ser útil. Sus planes son frustrados por la inteligencia y previsión de Shai.
+
+## Conexiones Relevantes
+* **Colegas:** [[Gaotona]], [[Ashravan]]
+* **Adversaria:** [[Shai]]
+
+## Apariciones
+* [[El alma del emperador]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Galladon.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Galladon.md
@@ -1,0 +1,22 @@
+---
+tags: personaje, Sel
+alias: [Gallo]
+---
+
+# Galladon
+
+## Resumen
+Galladon es un príncipe de Duladel que fue afectado por la [[Shaod]] y exiliado a [[Elantris]]. Allí, se convirtió en el mejor amigo y uno de los más fieles consejeros de [[Raoden]].
+
+## Apariencia y Personalidad
+Es un Dula, caracterizado por su piel oscura. Su rasgo más distintivo es su pesimismo y su actitud cínica, que a menudo expresa con su interjección característica, "¿Kolo?". A pesar de su pesimismo, es un amigo leal y valiente que siempre está al lado de [[Raoden]].
+
+## Historia
+En "La esperanza de Elantris", Galladon es uno de los líderes de Nueva Elantris. Se le ve enseñando a los demás elantrinos a dibujar aones correctamente, incluyendo la línea del Abismo que [[Raoden]] descubrió y que restaura el poder del [[AonDor]].
+
+## Conexiones Relevantes
+* **Amigos:** [[Raoden]], [[Karata]]
+
+## Apariciones
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Gaotona.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Gaotona.md
@@ -1,0 +1,22 @@
+---
+tags: personaje, Sel
+alias: [árbitro Gaotona]
+---
+
+# Gaotona
+
+## Resumen
+Gaotona es un árbitro anciano y de alto rango en la Facción de la Herencia del Imperio Rosa. A pesar de que su influencia política parece haber disminuido, es un hombre de principios, inteligente y el único de sus colegas que trata a [[Shai]] con cierto grado de respeto y curiosidad intelectual.
+
+## Apariencia y Personalidad
+Es descrito como un hombre mayor, de rasgos y dedos alargados. Es reflexivo, honorable y valora la verdad y el arte auténtico por encima de todo. Aunque considera la [[Falsificacion]] del alma una abominación, su curiosidad y su desesperación por salvar al imperio lo llevan a supervisar el trabajo de [[Shai]].
+
+## Historia
+Gaotona es uno de los cinco árbitros que contratan a [[Shai]] para Falsificar el alma del emperador [[Ashravan]]. Se convierte en su supervisor principal y, en un acto de sacrificio, se ofrece como sujeto de pruebas para los [[Sello_de_Alma|Sellos de Alma]] de Shai. A lo largo de la historia, desarrolla una relación compleja con ella, debatiendo sobre la naturaleza del arte, la verdad y el engaño. Al final, es él quien quema el cuaderno que contiene los secretos del alma Falsificada del emperador para proteger al imperio, reconociendo la obra de Shai como una obra maestra.
+
+## Conexiones Relevantes
+* **Colegas:** [[Frava]], [[Ashravan]]
+* **Relación compleja con:** [[Shai]]
+
+## Apariciones
+* [[El alma del emperador]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Karata.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Karata.md
@@ -1,0 +1,22 @@
+---
+tags: personaje, Sel
+---
+
+# Karata
+
+## Resumen
+Karata era una mujer noble de Arelon que fue afectada por la [[Shaod]] y arrojada a [[Elantris]]. Antes de la llegada de [[Raoden]], ella lideraba su propia banda, ofreciendo protección a los niños y a los más débiles a cambio de comida.
+
+## Apariencia y Personalidad
+Es una líder fuerte, pragmática y compasiva. A pesar de la dureza que requería su posición inicial en Elantris, tiene un profundo sentido de la responsabilidad hacia los más vulnerables.
+
+## Historia
+Karata y su banda se unen a [[Raoden]] y se convierten en una parte fundamental de la sociedad de Nueva Elantris. En "La esperanza de Elantris", se menciona que ella y [[Galladon]] están en una "biblioteca" secreta cuando comienza el ataque Fjordell, lo que indica su posición de confianza y conocimiento.
+
+## Conexiones Relevantes
+* **Amigos:** [[Raoden]], [[Galladon]]
+* **Protegidos:** [[Matisse]] y los demás niños de Elantris.
+
+## Apariciones
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Matisse.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Matisse.md
@@ -1,0 +1,21 @@
+---
+tags: personaje, Sel
+---
+
+# Matisse
+
+## Resumen
+Matisse es una joven elantrina y la protagonista de la historia "La esperanza de Elantris". Su función en Nueva Elantris es cuidar de los niños huérfanos.
+
+## Apariencia y Personalidad
+Matisse es valiente, responsable y compasiva. A pesar de su juventud y de haber sido una mendiga antes de la [[Shaod]], asume el rol de protectora de los niños más pequeños con gran seriedad. Considera a [[Dashe]] como una figura paterna.
+
+## Historia
+Durante el ataque de los soldados de Fjordell a Nueva Elantris, Matisse toma la iniciativa de evacuar a los cincuenta niños a su cargo. Los conduce a través de la ciudad en ruinas hacia un lugar seguro. En un acto de valentía, distrae a los soldados para dar tiempo a los demás a escapar, utilizando su conocimiento del [[AonDor]] para crear un destello de luz con Aon Ashe.
+
+## Conexiones Relevantes
+* **Figura Paterna:** [[Dashe]]
+* **Amigos:** [[Ashe]]
+
+## Apariciones
+* [[La esperanza de Elantris]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Raoden.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Raoden.md
@@ -1,0 +1,27 @@
+---
+tags: personaje, Sel
+alias: [Espíritu, Lord Espíritu]
+---
+
+# Raoden
+
+## Resumen
+Raoden es el príncipe de Arelon y el protagonista de la novela *Elantris*. Es conocido por su inquebrantable optimismo e inteligencia. Tras ser afectado por la [[Shaod]], es exiliado a la ciudad caída de [[Elantris]], donde en lugar de rendirse, organiza a sus decaídos habitantes y finalmente logra restaurar la magia de la ciudad.
+
+## Apariencia y Personalidad
+Como Elantrino restaurado, su piel tiene un brillo plateado y su cabello es de un blanco puro. Es un líder carismático, amable y extremadamente inteligente, con un talento para ver lo mejor en las personas y las situaciones.
+
+## Habilidades e Investidura
+Como Elantrino, Raoden es un maestro del [[AonDor]], la magia de [[Sel]] que consiste en dibujar símbolos (Aones) en el aire para crear efectos mágicos.
+
+## Historia
+En "La esperanza de Elantris", Raoden ya es rey de Arelon y está casado con [[Sarene]]. La historia se cuenta principalmente desde la perspectiva de otros personajes mientras él está ocupado en los asuntos del reino.
+
+## Conexiones Relevantes
+* **Esposa:** [[Sarene]]
+* **Amigos:** [[Galladon]], [[Karata]]
+* **Seon:** Ien
+
+## Apariciones
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Sarene.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Sarene.md
@@ -1,0 +1,23 @@
+---
+tags: personaje, Sel
+alias: [Lady Sarene]
+---
+
+# Sarene
+
+## Resumen
+Sarene es la princesa de Teod y la esposa de [[Raoden]]. Es una mujer de gran inteligencia política y una estratega brillante, cuyas acciones fueron fundamentales para salvar Arelon de la invasión de Fjordell en la novela *Elantris*.
+
+## Apariencia y Personalidad
+Es una mujer alta, a menudo considerada poco femenina para los estándares de su sociedad. Es extremadamente inteligente, franca, decidida y pragmática, con un gran talento para la política y la manipulación sutil.
+
+## Historia
+En "La esperanza de Elantris", Sarene es la reina de Arelon y está embarazada del hijo de [[Raoden]]. Preocupada por las tensiones políticas en la región, es ella quien toma la iniciativa de enviar armas a los elantrinos en Nueva Elantris para que puedan defenderse.
+
+## Conexiones Relevantes
+* **Esposo:** [[Raoden]]
+* **Seon:** [[Ashe]]
+
+## Apariciones
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/20_Personajes/Por_Mundo/Sel/Shai.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Sel/Shai.md
@@ -1,0 +1,26 @@
+---
+tags: personaje, Sel
+alias: [Wan ShaiLu, la Falsificadora]
+---
+
+# Shai
+
+## Resumen
+Shai, también conocida como Wan ShaiLu, es una [[Falsificacion|Falsificadora]] legendaria del pueblo MaiPon en [[Sel]]. Es contratada bajo coacción por los árbitros del Imperio Rosa para la tarea aparentemente imposible de recrear el alma del emperador [[Ashravan]], que ha quedado en estado vegetativo tras un intento de asesinato.
+
+## Apariencia y Personalidad
+Es una mujer de baja estatura con cabello lacio y largo. Shai es extremadamente inteligente, ingeniosa y orgullosa de su arte. A menudo cita las enseñanzas de su "tío Won", como la importancia de tener siempre un plan de reserva. A pesar de su oficio de ladrona, posee un profundo sentido artístico y ético sobre su trabajo.
+
+## Habilidades e Investidura
+Shai es una maestra de la [[Falsificacion]], un arte mágico selish que funciona reescribiendo el pasado de los objetos o las almas a través de [[Sello_de_Alma|Sellos de Alma]] intrincadamente tallados. Su habilidad es tal que puede crear [[Marca_de_Esencia|Marcas de Esencia]], unos sellos complejos que le permiten reescribir temporalmente su propia historia y personalidad para adquirir nuevas habilidades.
+
+## Historia
+La historia comienza con Shai capturada después de un intento fallido de robar el Cetro Lunar. En lugar de ser ejecutada, los árbitros le ofrecen su vida y sus preciadas Marcas de Esencia a cambio de que Falsifique una nueva alma para el emperador en cien días. A lo largo de la novela, Shai no solo trabaja en esta tarea monumental, sino que también planea su huida y desarrolla una compleja relación con el árbitro [[Gaotona]].
+
+## Conexiones Relevantes
+* **Aliados:** Desarrolla un respeto mutuo con [[Gaotona]].
+* **Enemigos:** [[Frava]] y los demás árbitros del Imperio Rosa.
+* **Pueblo:** MaiPon
+
+## Apariciones
+* [[El alma del emperador]]

--- a/Cosmere/20_Personajes/Por_Mundo/Taldain/Kenton.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Taldain/Kenton.md
@@ -1,0 +1,23 @@
+---
+tags: personaje, Taldain
+---
+
+# Kenton
+
+## Resumen
+Kenton es un Maestro de la Arena del planeta [[Taldain]] y el protagonista de la novela gráfica "Arena blanca". Es el hijo del líder de los Maestros de la Arena, el Mastrell Cardinal Praxton.
+
+## Apariencia y Personalidad
+Es un joven de cabello rubio y cara redondeada. Su rasgo más definitorio es su terquedad y su espíritu rebelde. Se niega a aceptar las limitaciones que otros le imponen debido a su escaso poder innato y cree firmemente que la habilidad y la creatividad son más importantes que la fuerza bruta.
+
+## Habilidades e Investidura
+Kenton es un [[Maestria_de_Arena|Maestro de la Arena]] considerado muy débil, ya que solo puede controlar una única "cinta" de arena a la vez. Sin embargo, su control sobre esa cinta es excepcionalmente preciso y fuerte, lo que le permite realizar proezas que otros Maestros más poderosos no pueden. También es el único Maestro de la Arena que lleva y usa una espada.
+
+## Historia
+El extracto de "Arena blanca" lo muestra insistiendo en unirse al Diem (la orden de los Maestros de la Arena) a pesar de su débil poder. Ocho años después, todavía como un acólito sin rango, decide recorrer la "Senda del Mastrell", una peligrosa prueba, para demostrar su valía en contra de los deseos de su padre.
+
+## Conexiones Relevantes
+* **Padre:** Praxton
+
+## Apariciones
+* [[Arena blanca]]

--- a/Cosmere/20_Personajes/Por_Mundo/Treno/Silencio_Montane.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Treno/Silencio_Montane.md
@@ -1,0 +1,24 @@
+---
+tags: personaje, Treno
+alias: [Zorro Blanco]
+---
+
+# Silencio Montane
+
+## Resumen
+Silencio Montane es una posadera de mediana edad que vive en una de las haciendas del continente fronterizo de [[Treno]]. En secreto, es también la cazarrecompensas más temida y eficaz de la región, conocida como el Zorro Blanco.
+
+## Apariencia y Personalidad
+Es una mujer robusta y dura, con una actitud estoica y pragmática forjada por la difícil vida en los bosques de Treno. Es extremadamente competente y recursiva. A pesar de su exterior endurecido, se preocupa profundamente por sus hijas, [[William Ann]] y [[Sebruki]]. Está atormentada por la memoria de su abuela, una Pionera que la sometió a un entrenamiento brutal.
+
+## Habilidades
+Silencio es una experta en supervivencia en los peligrosos bosques de Treno. Conoce las "Sencillas Reglas" para evitar atraer a las "umbras" ([[Sombras Cognitivas]]) y es hábil en el uso de la plata para combatirlas. Es una rastreadora y cazadora experta.
+
+## Historia
+La historia sigue a Silencio mientras se dispone a cazar a la peligrosa banda de Chesterton Divide para cobrar la recompensa y así salvar su posada de ser embargada por un recaudador de impuestos corrupto, Theopolis. Con la ayuda de su hija [[William Ann]], logra matar a los bandidos, pero debe enfrentarse tanto a las umbras como a otros cazarrecompensas que intentan robarle su presa.
+
+## Conexiones Relevantes
+* **Hijas:** [[William Ann]], [[Sebruki]] (adoptada)
+
+## Apariciones
+* [[Sombras por Silencio en los bosques del infierno]]

--- a/Cosmere/20_Personajes/Por_Mundo/Treno/William_Ann.md
+++ b/Cosmere/20_Personajes/Por_Mundo/Treno/William_Ann.md
@@ -1,0 +1,21 @@
+---
+tags: personaje, Treno
+---
+
+# William Ann
+
+## Resumen
+William Ann es la hija adolescente de [[Silencio Montane]].
+
+## Apariencia y Personalidad
+Es una joven alta y delgada. Aunque ha sido criada en los peligrosos bosques de [[Treno]], ha tenido una infancia más protegida que la de su madre. A pesar de su relativa inexperiencia, es valiente, leal y decidida.
+
+## Historia
+En "Sombras por Silencio en los bosques del infierno", William Ann insiste en acompañar a su madre en la peligrosa misión de cazar a la banda de Chesterton Divide. Demuestra su valor ayudando a matar a varios de los bandidos. Durante la confrontación final, es tocada por una "umbra" ([[Sombras Cognitivas]]), lo que le deja cicatrices permanentes en la piel.
+
+## Conexiones Relevantes
+* **Madre:** [[Silencio Montane]]
+* **Hermana adoptiva:** [[Sebruki]]
+
+## Apariciones
+* [[Sombras por Silencio en los bosques del infierno]]

--- a/Cosmere/30_Magia_e_Investidura/Alomancia.md
+++ b/Cosmere/30_Magia_e_Investidura/Alomancia.md
@@ -1,0 +1,29 @@
+---
+tags: concepto, magia, Scadrial
+alias: [Allomancy]
+---
+
+# Alomancia
+
+## Descripción General
+La Alomancia es uno de los tres principales Artes Metálicos nativos del planeta [[Scadrial]]. Se le conoce como el Arte de la [[Conservación]]. Los usuarios de la Alomancia, llamados **Alomantes**, son capaces de "quemar" metales que han ingerido para obtener poderes sobrenaturales.
+
+## Mecánicas
+La Alomancia funciona cuando un Alomante ingiere un metal específico y luego "lo quema" con su voluntad, consumiendo el metal y liberando [[Investidura]] para producir un efecto mágico. Cada metal alomántico otorga un poder diferente.
+
+Existen dos tipos principales de Alomantes:
+*   **Brumosos (Misting):** Alomantes que solo pueden quemar un tipo de metal.
+*   **Nacidos de la Bruma (Mistborn):** Alomantes que pueden quemar todos los metales alománticos.
+
+La Alomancia es un arte "end-positive", lo que significa que el metal no es la fuente del poder, sino una clave que permite al Alomante extraer poder directamente de [[Conservación]].
+
+## Conexiones Relevantes
+* **Esquirla asociada:** [[Conservación]]
+* **Artes relacionados:** [[Feruquimia]], [[Hemalurgia]]
+* **Mundos asociados:** [[Scadrial]]
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[El undécimo metal]]
+* [[Nacidos de la bruma: Historia Secreta]]
+* Serie de Wax y Wayne

--- a/Cosmere/30_Magia_e_Investidura/AonDor.md
+++ b/Cosmere/30_Magia_e_Investidura/AonDor.md
@@ -1,0 +1,27 @@
+---
+tags: concepto, magia, Sel
+alias: [Aon Dor]
+---
+
+# AonDor
+
+## Descripción General
+El AonDor es el principal sistema de magia de Arelon en el planeta [[Sel]]. Es utilizado por los Elantrinos, personas que han pasado por la [[Shaod]].
+
+## Mecánicas
+La magia se basa en dibujar símbolos, llamados Aones, en el aire, que producen una variedad de efectos mágicos. Los Aones son la base del lenguaje escrito de Arelon y cada uno tiene un significado y un poder asociados.
+
+El poder del AonDor está intrínsecamente ligado a la geografía. Para que un Aon funcione, su forma debe corresponderse con la geografía física de la tierra de Arelon. Tras la Reod, un terremoto masivo creó una enorme fisura en la tierra, alterando el mapa y haciendo que los Aones tradicionales fallaran.
+
+[[Raoden]] descubrió que para que la magia volviera a funcionar, era necesario añadir una línea extra a cada Aon para representar esta nueva fisura.
+
+## Relación con la Investidura
+El AonDor es una de las formas más directas de canalizar el poder del [[Dor]].
+
+## Conexiones Relevantes
+* **Usuarios Notables:** [[Raoden]], [[Galladon]]
+* **Mundos asociados:** [[Sel]]
+
+## Apariciones
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/30_Magia_e_Investidura/Dor.md
+++ b/Cosmere/30_Magia_e_Investidura/Dor.md
@@ -1,0 +1,16 @@
+---
+tags: concepto, magia, Sel
+---
+
+# Dor
+
+## Descripción General
+El Dor es el poder colectivo y polarizado de las Esquirlas [[Dominio]] y [[Devoción]]. Tras la muerte de sus Recipientes, esta inmensa cantidad de [[Investidura]] quedó atrapada en el Reino Cognitivo del planeta [[Sel]]. El Dor es la fuente que alimenta todas las formas de magia selish.
+
+## Mecánicas
+El acceso al Dor está intrínsecamente ligado a la geografía del planeta, ya que el poder reside en el Reino Cognitivo, que es sensible a la ubicación. Las reglas de la percepción y el propósito se ven muy magnificadas en Sel, hasta el punto de que el lenguaje —o funciones similares— conforman directamente la magia al extraerla del Reino Cognitivo y darle uso. Cambios sutiles en el territorio pueden tener efectos profundos en cómo se accede al Dor.
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Elantris]]
+* [[El alma del emperador]]

--- a/Cosmere/30_Magia_e_Investidura/El_undecimo_metal.md
+++ b/Cosmere/30_Magia_e_Investidura/El_undecimo_metal.md
@@ -1,0 +1,23 @@
+---
+tags: concepto, magia, Scadrial
+alias: [Malatium]
+---
+
+# El undécimo metal
+
+## Descripción General
+El undécimo metal es el nombre que se le dio al **malatium**, una aleación de [[atium]] y oro. Es uno de los metales superiores, a menudo llamados "metales de Dios".
+
+## Mecánicas Alománticas
+Cuando un Nacido de la Bruma quema malatium, obtiene una visión temporal que le permite ver el pasado de otras personas, o una versión de quiénes podrían haber sido. Muestra una imagen de su "verdadero yo" o de un estado anterior.
+
+## Historia
+En la historia "El undécimo metal", [[Kelsier]] lo adquiere creyendo que es un arma secreta para derrotar al lord Legislador. Al quemarlo durante su confrontación final, ve una imagen del pasado del lord Legislador como un hombre terrisano, lo que le revela parte de su verdadera naturaleza pero no le proporciona una forma de derrotarlo.
+
+## Conexiones Relevantes
+* **Artes relacionados:** [[Alomancia]]
+* **Metales base:** Atium, Oro.
+
+## Apariciones
+* [[El undécimo metal]]
+* Trilogía original de Nacidos de la Bruma

--- a/Cosmere/30_Magia_e_Investidura/Falsificacion.md
+++ b/Cosmere/30_Magia_e_Investidura/Falsificacion.md
@@ -1,0 +1,25 @@
+---
+tags: concepto, magia, Sel
+alias: [Forgery]
+---
+
+# Falsificación
+
+## Descripción General
+La Falsificación (Forgery) es una forma de [[Investidura]] practicada en el planeta [[Sel]], predominantemente por el pueblo MaiPon. El arte consiste en alterar el estado de un objeto o persona reescribiendo su pasado. Un practicante de este arte es conocido como un Falsificador.
+
+## Mecánicas
+Para Falsificar un objeto, el Falsificador debe primero comprender su historia y naturaleza. A continuación, talla un [[Sello_de_Alma]] con un diseño intrincado que representa una historia alternativa plausible para el objeto. Cuando se aplica el sello, el alma del objeto es convencida de esta nueva historia, y su forma física cambia para reflejarla.
+
+La clave de una Falsificación exitosa es la **plausibilidad**. Una historia alternativa muy improbable resultará en un sello que no "prende" o que dura muy poco. Por el contrario, una Falsificación bien investigada y creíble puede ser casi permanente. Esta magia también puede usarse en seres vivos, aunque es mucho más complejo y se considera una abominación en muchas culturas.
+
+## Relación con la Investidura
+La Falsificación extrae su poder del [[Dor]], la fuente de Investidura de [[Sel]].
+
+## Conexiones Relevantes
+* **Términos asociados:** [[Sello_de_Alma]], [[Marca_de_Esencia]]
+* **Personajes que lo usan:** [[Shai]]
+* **Mundos asociados:** [[Sel]]
+
+## Apariciones
+* [[El alma del emperador]]

--- a/Cosmere/30_Magia_e_Investidura/Feruquimia.md
+++ b/Cosmere/30_Magia_e_Investidura/Feruquimia.md
@@ -1,0 +1,22 @@
+---
+tags: concepto, magia, Scadrial
+alias: [Feruchemy]
+---
+
+# Feruquimia
+
+## Descripción General
+La Feruquimia es uno de los tres principales Artes Metálicos nativos del planeta [[Scadrial]]. Se le conoce como el Arte del Equilibrio. Los usuarios, llamados **Feruquimistas**, pueden almacenar atributos propios (como la fuerza, la velocidad, la salud o los recuerdos) en objetos de metal, conocidos como **mentemantales**, para recuperarlos más tarde.
+
+## Mecánicas
+Un Feruquimista pasa un período de tiempo siendo más débil en un atributo particular mientras almacena esa energía en un mentemental. Por ejemplo, puede pasar un día siendo físicamente débil para almacenar fuerza en un brazalete de peltre. Más tarde, puede "aprovechar" el mentemental para recuperar ese atributo a un nivel muy superior al normal durante un corto período de tiempo.
+
+La Feruquimia es un arte "end-neutral": el poder proviene del propio Feruquimista y no se crea ni se destruye, solo se almacena y se recupera. Originalmente, era un arte exclusivo de los terrisanos.
+
+## Conexiones Relevantes
+* **Artes relacionados:** [[Alomancia]], [[Hemalurgia]]
+* **Mundos asociados:** [[Scadrial]]
+* **Usuarios Notables:** [[Sazed]]
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma

--- a/Cosmere/30_Magia_e_Investidura/Hemalurgia.md
+++ b/Cosmere/30_Magia_e_Investidura/Hemalurgia.md
@@ -1,0 +1,26 @@
+---
+tags: concepto, magia, Scadrial
+alias: [Hemalurgy]
+---
+
+# Hemalurgia
+
+## Descripción General
+La Hemalurgia es uno de los tres principales Artes Metálicos nativos del planeta [[Scadrial]]. Se le conoce como el Arte de la [[Ruina]]. Es un proceso que permite robar poderes o atributos de una persona y otorgárselos a otra mediante el uso de clavos metálicos.
+
+## Mecánicas
+El proceso hemalúrgico es inherentemente violento y destructivo. Implica atravesar el cuerpo de una persona con un pincho de un metal específico, generalmente matándola en el proceso. Este acto "carga" el clavo con una porción del alma o del poder de la víctima (como su [[Alomancia]] o [[Feruquimia]]).
+
+Luego, este clavo se inserta en un punto de anclaje preciso en el cuerpo de otra persona, otorgándole el poder robado. Este proceso siempre resulta en una pérdida neta de poder (es "end-negative") y abre el alma del receptor a la influencia externa, especialmente a la de [[Ruina]].
+
+Khriss considera que la Hemalurgia es la magia con el mayor impacto potencial en el [[Cosmere]], ya que puede usarse para robar cualquier tipo de [[Investidura]] de cualquier planeta.
+
+## Conexiones Relevantes
+* **Esquirla asociada:** [[Ruina]]
+* **Artes relacionados:** [[Alomancia]], [[Feruquimia]]
+* **Mundos asociados:** [[Scadrial]]
+* **Creaciones Notables:** [[Inquisidores de Acero]], [[Koloss]]
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/30_Magia_e_Investidura/Maestria_de_Arena.md
+++ b/Cosmere/30_Magia_e_Investidura/Maestria_de_Arena.md
@@ -1,0 +1,22 @@
+---
+tags: concepto, magia, Taldain
+alias: [Sand Mastery]
+---
+
+# Maestría de la Arena
+
+## Descripción General
+La Maestría de la Arena es el sistema de [[Investidura]] nativo del Lado Diurno del planeta [[Taldain]]. Permite a sus usuarios, conocidos como Maestros de la Arena, manipular la arena blanca del planeta.
+
+## Mecánicas
+La Investidura en Taldain desciende de la luz solar y es absorbida por una microflora que crece en la superficie de la arena, dándole su color blanco. Cuando un Maestro de la Arena proporciona agua (generalmente de su propio cuerpo) a esta microflora, se desencadena una reacción en cadena que libera la Investidura.
+
+El Maestro de la Arena puede entonces formar un nexo cognitivo con la arena y controlarla, a menudo formando "cintas" para atacar, defenderse o manipular objetos. Es una magia que depende más de la habilidad y la precisión que de la fuerza bruta. Un uso excesivo puede llevar a una peligrosa deshidratación.
+
+## Conexiones Relevantes
+* **Esquirla asociada:** [[Autonomía]]
+* **Mundos asociados:** [[Taldain]]
+* **Usuarios Notables:** [[Kenton]]
+
+## Apariciones
+* [[Arena blanca]]

--- a/Cosmere/30_Magia_e_Investidura/Marca_de_Esencia.md
+++ b/Cosmere/30_Magia_e_Investidura/Marca_de_Esencia.md
@@ -1,0 +1,23 @@
+---
+tags: concepto, magia, Sel
+alias: [Essence Mark]
+---
+
+# Marca de Esencia
+
+## Descripción General
+Una Marca de Esencia es el tipo más poderoso y complejo de [[Sello_de_Alma]]. Está específicamente diseñada para ser utilizada en una persona, reescribiendo temporalmente su historia, personalidad y alma. Su posesión es ilegal en el Imperio Rosa.
+
+## Mecánicas
+Cada Marca de Esencia debe ser armonizada con un individuo concreto, un proceso que requiere años de estudio sobre la propia alma para crear una Falsificación creíble. Su efecto es temporal, durando aproximadamente un día antes de necesitar ser reaplicada.
+
+[[Shai]] utiliza sus Marcas de Esencia para transformarse en diferentes versiones de sí misma que podría haber sido, otorgándole nuevas habilidades, conocimientos y apariencias físicas. Por ejemplo, una de sus marcas la convierte en "Shaizan", una guerrera experta.
+
+## Conexiones Relevantes
+* **Magia asociada:** [[Falsificacion]]
+* **Herramienta base:** [[Sello_de_Alma]]
+* **Personajes que lo usan:** [[Shai]]
+* **Mundos asociados:** [[Sel]]
+
+## Apariciones
+* [[El alma del emperador]]

--- a/Cosmere/30_Magia_e_Investidura/Sello_de_Alma.md
+++ b/Cosmere/30_Magia_e_Investidura/Sello_de_Alma.md
@@ -1,0 +1,21 @@
+---
+tags: concepto, magia, Sel
+alias: [Soulstamp]
+---
+
+# Sello de Alma
+
+## Descripción General
+Un Sello de Alma (Soulstamp) es la herramienta física utilizada en el arte de la [[Falsificacion]]. Es un sello, a menudo tallado en un material especial como la "piedra de alma", que contiene el patrón de una nueva historia para un objeto o persona.
+
+## Mecánicas
+El Falsificador talla un diseño complejo en el sello que representa la historia alternativa que desea imponer. Al presionar el sello contra el objeto, la [[Investidura]] del [[Dor]] es canalizada, y si la Falsificación es lo suficientemente plausible, el objeto cambia para coincidir con la nueva historia. El sello debe permanecer en el objeto para que el cambio se mantenga.
+
+## Conexiones Relevantes
+* **Magia asociada:** [[Falsificacion]]
+* **Tipos notables:** [[Marca_de_Esencia]]
+* **Personajes que lo usan:** [[Shai]]
+* **Mundos asociados:** [[Sel]]
+
+## Apariciones
+* [[El alma del emperador]]

--- a/Cosmere/30_Magia_e_Investidura/Shaod.md
+++ b/Cosmere/30_Magia_e_Investidura/Shaod.md
@@ -1,0 +1,27 @@
+---
+tags: concepto, magia, Sel
+---
+
+# Shaod
+
+## Descripción General
+La Shaod es el nombre que se le da a una transformación mágica que afecta aleatoriamente a los habitantes de Arelon y otras regiones cercanas en el planeta [[Sel]].
+
+## Mecánicas
+Antes de la caída de [[Elantris]] (un evento conocido como la Reod), la Shaod transformaba a una persona en un Elantrino, otorgándole una piel plateada brillante, cabello blanco y acceso al [[AonDor]].
+
+Después de la Reod, la transformación se corrompió. Las personas afectadas por la Shaod sufrían la caída del cabello y la aparición de manchas oscuras en la piel. Su corazón dejaba de latir y, lo más importante, su cuerpo perdía la capacidad de sanar. Cualquier herida, por pequeña que fuera, infligía un dolor perpetuo, lo que llevaba a la mayoría de los afectados a la locura. Este estado fue revertido cuando [[Raoden]] reparó el [[AonDor]].
+
+## Relación con la Investidura
+La Shaod es una manifestación directa de la [[Investidura]] del [[Dor]] actuando sobre un ser humano.
+
+## Personajes Afectados
+* [[Raoden]]
+* [[Galladon]]
+* [[Karata]]
+* [[Matisse]]
+* [[Dashe]]
+
+## Apariciones
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Ambicion.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Ambicion.md
@@ -1,0 +1,17 @@
+---
+tags: concepto, esquirla
+alias: [Ambition]
+---
+
+# Ambición
+
+## Descripción General
+Ambición fue una de las dieciséis [[Esquirlas de Adonalsium]] originales.
+
+## Historia
+Poco después de la Fragmentación, la Esquirla Ambición se enfrentó a [[Odium]] en el sistema de [[Treno]]. Aunque la batalla principal tuvo lugar en el espacio interplanetario, Ambición fue herida de muerte durante el conflicto.
+
+Posteriormente, fue perseguida por Odium y finalmente Astillada en otro lugar del [[Cosmere]]. Las "ondas de choque" de este conflicto y la dispersión de fragmentos de su poder alteraron profundamente el planeta [[Treno]].
+
+## Apariciones
+* [[Arcanum Ilimitado]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Autonomia.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Autonomia.md
@@ -1,0 +1,21 @@
+---
+tags: concepto, esquirla
+alias: [Autonomy]
+---
+
+# Autonomía
+
+## Descripción General
+Autonomía es una de las dieciséis [[Esquirlas de Adonalsium]]. Su intención o mandato se centra en la supervivencia, la independencia y el autogobierno.
+
+## Actividad en el Cosmere
+La Esquirla Autonomía reside principalmente en el planeta [[Taldain]]. Allí, ha impuesto una estricta política de aislacionismo que impide el viaje hacia y desde el planeta.
+
+Sin embargo, como señala Khriss, esta política contrasta fuertemente con la conocida injerencia de Autonomía en otros planetas del [[Cosmere]], a menudo a través de avatares.
+
+## Conexiones Relevantes
+* **Mundos asociados:** [[Taldain]] (principalmente)
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* Mencionada en la serie de Wax y Wayne.

--- a/Cosmere/40_Entidades_y_Fragmentos/Aviar.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Aviar.md
@@ -1,0 +1,20 @@
+---
+tags: concepto, entidad, Primero del Sol
+---
+
+# Aviar
+
+## Descripción General
+Los Aviar son aves del planeta [[Primero del Sol]] que han obtenido habilidades mágicas a través de una relación simbiótica con un parásito local.
+
+## Mecánicas
+Los Aviar obtienen sus poderes al comer un tipo específico de gusano que solo se encuentra en la isla de Patji. Cada tipo de gusano otorga un talento mágico diferente.
+
+Estos talentos pueden ser compartidos con los humanos con los que el Aviar se vincula. Las habilidades concedidas son a menudo de naturaleza cognitiva o sensorial, como la capacidad de advertir del peligro inminente (mostrando al humano una visión de su propio cadáver), ver el futuro inmediato, o proteger la mente de la detección por parte de depredadores psíquicos.
+
+## Conexiones Relevantes
+* **Mundos asociados:** [[Primero del Sol]]
+* **Usuarios Notables:** [[Sexto del Ocaso]]
+
+## Apariciones
+* [[Sexto del Ocaso]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Conservacion.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Conservacion.md
@@ -1,0 +1,27 @@
+---
+tags: concepto, esquirla
+alias: [Leras, Borrón]
+---
+
+# Conservación
+
+## Descripción General
+Conservación es una de las dieciséis [[Esquirlas de Adonalsium]]. Su intención o mandato es preservar y mantener las cosas estáticas e inmutables. Junto con [[Ruina]], creó el planeta de [[Scadrial]].
+
+## Recipiente
+El Recipiente original de la Esquirla de Conservación era un hombre llamado Leras.
+
+## Conflicto
+La intención de Conservación estaba en conflicto directo con la de [[Ruina]]. Para proteger el mundo que habían creado, Conservación sacrificó una gran parte de su poder y su mente para crear una prisión para Ruina. Esta prisión era el [[Pozo de la Ascensión]].
+
+En "Nacidos de la bruma: Historia Secreta", el espíritu de Leras, muy debilitado y con la mente fragmentada, se encuentra con [[Kelsier]] en el [[Reino Cognitivo]]. Kelsier lo apoda "Borrón" (Fuzz). Leras ayuda a Kelsier a anclarse al Pozo y le revela fragmentos del conflicto cósmico. Su poder se manifiesta en el mundo físico como las brumas. Finalmente, su poder es tomado brevemente por [[Vin]] antes de pasar a [[Sazed]].
+
+## Conexiones Relevantes
+* **Esquirla opuesta:** [[Ruina]]
+* **Mundos asociados:** [[Scadrial]]
+* **Artes Metálicos asociados:** [[Alomancia]], [[Feruquimia]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Devocion.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Devocion.md
@@ -1,0 +1,18 @@
+---
+tags: concepto, esquirla
+---
+
+# Devoción
+
+## Descripción General
+Devoción fue una de las dieciséis [[Esquirlas de Adonalsium]] que surgieron tras la Fragmentación. Junto con [[Dominio]], se asentó en el planeta de [[Sel]].
+
+En algún momento del pasado lejano, el Recipiente de Devoción fue asesinado y el poder de la Esquirla, Astillado. Su poder ahora conforma una parte del [[Dor]].
+
+## Conexiones Relevantes
+* **Esquirla asociada:** [[Dominio]]
+* **Mundos asociados:** [[Sel]]
+* **Astillas:** [[Seones]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Dominio.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Dominio.md
@@ -1,0 +1,18 @@
+---
+tags: concepto, esquirla
+---
+
+# Dominio
+
+## Descripción General
+Dominio fue una de las dieciséis [[Esquirlas de Adonalsium]] que surgieron tras la Fragmentación. Junto con [[Devoción]], se asentó en el planeta de [[Sel]].
+
+En algún momento del pasado lejano, el Recipiente de Dominio fue asesinado y el poder de la Esquirla, Astillado. Su poder ahora conforma una parte del [[Dor]].
+
+## Conexiones Relevantes
+* **Esquirla asociada:** [[Devoción]]
+* **Mundos asociados:** [[Sel]]
+* **Astillas:** [[Skaze]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Insomnes.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Insomnes.md
@@ -1,0 +1,19 @@
+---
+tags: entidad, cosmere
+alias: [Sleepless, Dysian Aimian]
+---
+
+# Insomnes
+
+## Descripción General
+Los Insomnes (Sleepless) son una antigua raza no humana del [[Cosmere]], también conocidos como Dysian Aimian. Son seres compuestos, formados por enjambres de criaturas más pequeñas, parecidas a cremlinos, llamadas "hordinos". Estos hordinos colaboran para formar un cuerpo y una conciencia unificada.
+
+## Mecánicas y Biología
+Los Insomnes pueden alterar su forma y apariencia a voluntad, criando selectivamente y reconfigurando sus hordinos para imitar diferentes formas, incluyendo la humana. Cada hordino puede tener una función específica (ojos, piel, músculo). Pueden desprender hordinos individuales para que actúen como espías.
+
+## Personajes Notables
+* **Arclo:** Un Insomne que se encuentra con [[Lift]] en Yeddaw, haciéndose pasar por un anciano filósofo.
+
+## Apariciones
+* [[Danzante del Filo]]
+* Mencionados o vistos en otros libros del [[Archivo de las Tormentas]].

--- a/Cosmere/40_Entidades_y_Fragmentos/Koloss.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Koloss.md
@@ -1,0 +1,26 @@
+---
+tags: concepto, entidad, Scadrial
+---
+
+# Koloss
+
+## Descripción General
+Los koloss son una raza de criaturas humanoides de piel azul que habitan en [[Scadrial]]. Son conocidos por su gran fuerza, su naturaleza brutal y su sociedad basada en la dominación del más fuerte.
+
+## Mecánicas y Biología
+Los koloss no son una especie que se reproduzca de forma natural; se crean a partir de seres humanos mediante el uso de la [[Hemalurgia]]. El proceso implica clavar cuatro clavos de hierro en el cuerpo de un humano, lo que provoca una transformación salvaje.
+
+Una vez transformados, los koloss crecen continuamente a lo largo de sus vidas. Su piel no crece con ellos, por lo que se estira y se rompe a medida que aumentan de tamaño, revelando la musculatura roja de debajo. Los koloss más viejos son gigantescos, pero su corazón no puede soportar su tamaño indefinidamente, por lo que a menudo mueren de un ataque al corazón.
+
+## Sociedad
+Los koloss viven en tribus o clanes. Su sociedad es jerárquica y se basa puramente en la fuerza. El líder es el más fuerte, y su posición es constantemente desafiada por otros miembros del clan que aspiran a gobernar.
+
+## Conexiones Relevantes
+* **Magia asociada:** [[Hemalurgia]]
+* **Esquirla asociada:** [[Ruina]]
+* **Tipos relacionados:** [[Sangre-Koloss]]
+* **Mundos asociados:** [[Scadrial]]
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[Alomante Jak y los Pozos de Eltania]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Nalan.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Nalan.md
@@ -18,9 +18,13 @@ Como Heraldo, Nalan es inmortal y posee una [[Hoja de Honor]]. También es un [[
 ### Sucesos en 'Palabras radiantes'
 Nalan, bajo el alias de Oscuridad, aparece en los interludios, cazando y matando a los nuevos potenciadores que surgen en [[Roshar]]. Al final del libro, revive a [[Szeth-hijo-hijo-Vallano]] y lo recluta para los [[Rompedores del Cielo]].
 
+### Sucesos en 'Danzante del Filo'
+Nalan continúa su misión de ejecutar a los nuevos Radiantes en la ciudad de Yeddaw. Persigue a una [[Danzantes del Filo|Danzante del Filo]] conocida como "la Tocón". Se enfrenta a [[Lift]], a quien ya había intentado matar en Azir. Durante su duelo en medio de la [[Tormenta Eterna]], Lift usa su nuevo juramento para "escuchar" el dolor de Nalan, forzándolo a confrontar la realidad de que las Desolaciones han regresado y que su cruzada de siglos ha sido en vano. Esto le provoca una crisis mental y huye.
+
 ## Conexiones Relevantes
 * **Orden:** [[Rompedores del Cielo]].
 * **Subordinado:** [[Szeth-hijo-hijo-Vallano]].
 
 ## Apariciones
 * [[Palabras radiantes]]
+* [[Danzante del Filo]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Ruina.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Ruina.md
@@ -1,0 +1,27 @@
+---
+tags: concepto, esquirla
+alias: [Ati]
+---
+
+# Ruina
+
+## Descripción General
+Ruina es una de las dieciséis [[Esquirlas de Adonalsium]]. Su intención o mandato es la entropía, la decadencia y la destrucción final de todas las cosas. Junto con [[Conservación]], creó el planeta de [[Scadrial]].
+
+## Recipiente
+El Recipiente original de la Esquirla de Ruina era un hombre bondadoso y generoso llamado Ati. Con el tiempo, el poder de la Esquirla corrompió su personalidad.
+
+## Conflicto
+El conflicto entre Ruina y [[Conservación]] es la fuerza central que da forma a la historia de Scadrial. Ruina fue atrapado por Conservación durante milenios, pero su influencia se filtró en el mundo, especialmente a través de la [[Hemalurgia]].
+
+"Nacidos de la bruma: Historia Secreta" muestra cómo Ruina manipula a [[Kelsier]] y a otros para lograr su liberación del [[Pozo de la Ascensión]]. Tras ser liberado, su poder se manifiesta como una presencia oscura y corruptora en el cielo y en la mente de aquellos con clavos hemalúrgicos. Se enfrenta directamente a Kelsier en el [[Reino Cognitivo]], revelando que Kelsier ha sido su peón. Finalmente es derrotado cuando [[Vin]] toma el poder de [[Conservación]] y se sacrifica para destruirlo.
+
+## Conexiones Relevantes
+* **Esquirla opuesta:** [[Conservación]]
+* **Mundos asociados:** [[Scadrial]]
+* **Arte Metálico asociado:** [[Hemalurgia]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Sangre-Koloss.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Sangre-Koloss.md
@@ -1,0 +1,23 @@
+---
+tags: concepto, entidad, Scadrial
+alias: [Koloss-blooded]
+---
+
+# Sangre-Koloss
+
+## Descripción General
+Los "Sangre-Koloss" (Koloss-blooded) son los descendientes de los [[Koloss]]. A diferencia de los koloss completos, que se crean a través de la [[Hemalurgia]], los Sangre-Koloss nacen de forma natural.
+
+## Mecánicas y Biología
+Los Sangre-Koloss heredan algunas de las características físicas de sus antepasados, como una gran fuerza y resistencia, y a menudo un ligero tinte azulado o grisáceo en la piel. Sin embargo, no sufren la degradación mental asociada a la transformación hemalúrgica, por lo que son tan inteligentes como cualquier ser humano.
+
+A los Sangre-Koloss se les ofrece la opción de someterse a la transformación completa para convertirse en un koloss al llegar a la pubertad. Muchos, sin embargo, eligen abandonar sus tribus e integrarse en la sociedad humana.
+
+## Conexiones Relevantes
+* **Raza parental:** [[Koloss]]
+* **Mundos asociados:** [[Scadrial]]
+* **Personajes Notables:** [[Elizandra Dramali]]
+
+## Apariciones
+* [[Alomante Jak y los Pozos de Eltania]]
+* Serie de Wax y Wayne

--- a/Cosmere/40_Entidades_y_Fragmentos/Seones.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Seones.md
@@ -1,0 +1,19 @@
+---
+tags: concepto, entidad, Sel
+alias: [seon]
+---
+
+# Seones
+
+## Descripción General
+Los seones son [[Astillas de Adonalsium|Astillas]] conscientes de la [[Investidura]] de la Esquirla [[Devoción]]. Se manifiestan en el planeta de [[Sel]] y a menudo se vinculan con los humanos. Han desarrollado particularidades de estilo humano y son una de las entidades más misteriosas y únicas de Sel.
+
+## Conexiones Relevantes
+* **Esquirla asociada:** [[Devoción]]
+* **Equivalente:** [[Skaze]] (asociados a [[Dominio]])
+* **Mundos asociados:** [[Sel]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Elantris]]
+* [[La esperanza de Elantris]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Skaze.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Skaze.md
@@ -1,0 +1,17 @@
+---
+tags: concepto, entidad, Sel
+alias: [skaze]
+---
+
+# Skaze
+
+## Descripción General
+Los skaze son [[Astillas de Adonalsium|Astillas]] conscientes de la [[Investidura]] de la Esquirla [[Dominio]]. Se manifiestan en el planeta de [[Sel]] y, al igual que los [[Seones]], son seres conscientes que han desarrollado particularidades de estilo humano.
+
+## Conexiones Relevantes
+* **Esquirla asociada:** [[Dominio]]
+* **Equivalente:** [[Seones]] (asociados a [[Devoción]])
+* **Mundos asociados:** [[Sel]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]

--- a/Cosmere/40_Entidades_y_Fragmentos/Wyndle.md
+++ b/Cosmere/40_Entidades_y_Fragmentos/Wyndle.md
@@ -8,14 +8,18 @@ tags: entidad, spren, Roshar
 Un [[cultivacispren]] que se vincula con [[Lift]]. Es un [[spren]] quejumbroso y preocupado, que a menudo se lamenta de la imprudencia de su Radiante.
 
 ## Apariencia y Personalidad
-Wyndle aparece como una enredadera de color verde oscuro que puede crecer y moverse a voluntad. A menudo forma un rostro en las enredaderas para hablar con [[Lift]]. Es un [[spren]] cauteloso y preocupado, que se siente abrumado por la responsabilidad de tener a una [[Danzante del Filo]] como [[Lift]].
+Wyndle aparece como una enredadera de color verde oscuro que puede crecer y moverse a voluntad, a menudo con pequeños cristales que brotan de ella. Forma un rostro en las enredaderas para hablar con [[Lift]]. Es un [[spren]] cauteloso y preocupado, que a menudo se lamenta de haber sido elegido para vincularse con una Radiante tan imprudente como [[Lift]]. Antes de vincularse, era un "jardinero" en [[Shadesmar]], donde cultivaba almas de objetos como sillas para convertirlas en cristales.
 
 ## Historia
 ### Sucesos en 'Palabras radiantes'
 Wyndle forma un lazo nahel con [[Lift]], convirtiéndola en una [[Danzante del Filo]]. La acompaña en sus aventuras y la ayuda a desarrollar sus poderes.
+
+### Sucesos en 'Danzante del Filo'
+Wyndle acompaña a Lift a Yeddaw. Después de que Lift pronuncia el Tercer Ideal de los Danzantes del Filo, Wyndle gana la habilidad de manifestarse en el Reino Físico como una vara de metal, que Lift puede usar como arma (o como un tenedor gigante).
 
 ## Conexiones Relevantes
 * **Vinculado a:** [[Lift]].
 
 ## Apariciones
 * [[Palabras radiantes]]
+* [[Danzante del Filo]]

--- a/Cosmere/50_Lore_y_Conceptos/Ire.md
+++ b/Cosmere/50_Lore_y_Conceptos/Ire.md
@@ -1,0 +1,18 @@
+---
+tags: concepto, organizacion
+---
+
+# Ire
+
+## Descripción General
+Los Ire son una organización o grupo de individuos que poseen un conocimiento profundo sobre los sucesos del planeta [[Sel]], especialmente en lo que respecta a sus [[Esquirlas de Adonalsium|Esquirlas]] y el [[Dor]].
+
+Según Khriss, se niegan a compartir información y han rechazado sus solicitudes de colaboración.
+
+## Conexiones Relevantes
+* **Mundos asociados:** [[Sel]]
+* **Miembros conocidos:** [[Iyatil]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/50_Lore_y_Conceptos/La_Maldad.md
+++ b/Cosmere/50_Lore_y_Conceptos/La_Maldad.md
@@ -1,0 +1,21 @@
+---
+tags: concepto, Treno
+alias: [The Evil]
+---
+
+# La Maldad
+
+## Descripción General
+La Maldad es una fuerza misteriosa y peligrosa que consumió por completo el continente principal de [[Treno]], ahora conocido como el Mundo Caído o Patria.
+
+## Naturaleza
+La naturaleza exacta de La Maldad es desconocida, pero se la describe como una "oscuridad acechante" y una "potencia terrible". Khriss especula que es una fuerza que se alimenta de las almas de los seres humanos.
+
+Los habitantes del continente fronterizo de Treno viven con el temor constante de que La Maldad pueda encontrar una forma de cruzar el océano y alcanzarlos.
+
+## Conexiones Relevantes
+* **Mundos asociados:** [[Treno]]
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Sombras por Silencio en los bosques del infierno]]

--- a/Cosmere/50_Lore_y_Conceptos/Perpendicularidad.md
+++ b/Cosmere/50_Lore_y_Conceptos/Perpendicularidad.md
@@ -1,0 +1,26 @@
+---
+tags: concepto, cosmere
+alias: [Perpendicularity]
+---
+
+# Perpendicularidad
+
+## Descripción General
+Una Perpendicularidad es un lugar en el [[Cosmere]] donde los tres reinos ([[Realmatica|Físico, Cognitivo y Espiritual]]) se superponen y se tocan de forma estable. Estos puntos de fricción realmática son cruciales porque permiten el tránsito de seres y objetos entre los reinos, funcionando como una especie de "puerto" para los viajeros interplanetarios (worldhoppers).
+
+## Mecánicas
+Generalmente, las Perpendicularidades son creadas por la inmensa concentración de [[Investidura]] de una [[Esquirlas de Adonalsium|Esquirla]] en un planeta. Este poder concentrado deforma el espacio realmático, creando un nexo entre los tres reinos.
+
+En el Reino Físico, una Perpendicularidad a menudo se manifiesta como un estanque o pozo de Investidura líquida y pura.
+
+## Ejemplos Notables
+* **[[Scadrial]]:**
+    *   El [[Pozo de la Ascensión]] (Perpendicularidad de [[Conservación]]).
+    *   Los Pozos de Hathsin, la fuente del [[atium]] (Perpendicularidad de [[Ruina]]).
+* **[[Roshar]]:**
+    *   Los [[Puerta Jurada|Puertos Jurados]] en [[Urithiru]], que conectan con [[Shadesmar]].
+    *   El estanque en los picos de las montañas de los Cuernocantores.
+
+## Apariciones
+* [[Nacidos de la bruma: Historia Secreta]]
+* Mencionado o implícito en toda la saga del Cosmere.

--- a/Cosmere/50_Lore_y_Conceptos/Pozo_de_la_Ascension.md
+++ b/Cosmere/50_Lore_y_Conceptos/Pozo_de_la_Ascension.md
@@ -1,0 +1,23 @@
+---
+tags: concepto, lugar, Scadrial
+alias: [Well of Ascension]
+---
+
+# Pozo de la Ascensión
+
+## Descripción General
+El Pozo de la Ascensión es la [[Perpendicularidad]] de la Esquirla [[Conservación]] en el planeta [[Scadrial]]. Se manifiesta en el Reino Físico como un estanque de [[Investidura]] líquida y brillante, ubicado en una caverna bajo la ciudad de Luthadel, dentro de Kredik Shaw.
+
+## Mecánicas
+El Pozo es el nexo del poder de [[Conservación]] y la cerradura de la prisión de [[Ruina]]. Cada 1024 años, el Pozo se llena por completo. Cualquier persona que entre en él en ese momento puede tomar el poder de la Esquirla y Ascender a un estado de divinidad temporal, con la capacidad de alterar la realidad a gran escala.
+
+La profecía del Héroe de las Eras, manipulada por [[Ruina]], indicaba que el Héroe debía "renunciar" al poder. Sin embargo, este acto era una trampa: al renunciar al poder, se lo estaría cediendo a Ruina, rompiendo así la prisión y liberándolo.
+
+## Historia
+*   **Rashek (El lord Legislador):** Usó el poder del Pozo para rehacer el mundo y establecer el Imperio Final.
+*   **[[Vin]]:** Mil años después, llegó al Pozo y, engañada por la influencia de [[Ruina]], liberó el poder, liberando así a la Esquirla.
+*   **[[Kelsier]]:** Tras su muerte, su espíritu se ancló al Pozo en el [[Reino Cognitivo]] para evitar ser arrastrado al Más Allá y poder seguir observando e influyendo en el mundo.
+
+## Apariciones
+* Trilogía original de Nacidos de la Bruma
+* [[Nacidos de la bruma: Historia Secreta]]

--- a/Cosmere/50_Lore_y_Conceptos/Realmatica.md
+++ b/Cosmere/50_Lore_y_Conceptos/Realmatica.md
@@ -1,0 +1,24 @@
+---
+tags: concepto, cosmere
+alias: [Teoría Realmática, Tres Reinos]
+---
+
+# Realmática
+
+## Descripción General
+La Teoría Realmática es el modelo fundamental que describe la estructura del [[Cosmere]]. Postula que toda existencia se manifiesta en tres Reinos o planos superpuestos: el Reino Físico, el Reino Cognitivo y el Reino Espiritual.
+
+### Reino Físico
+Es el mundo material que los seres vivos perciben normalmente. Se rige por las leyes de la física, la materia y la energía.
+
+### Reino Cognitivo
+Es el reino del pensamiento, la percepción y la consciencia. Los objetos y lugares del Reino Físico tienen una "sombra cognitiva" que está moldeada por cómo son percibidos por las mentes. Por ejemplo, la tierra es sólida pero el agua es líquida en el Físico, pero en el Cognitivo de [[Roshar]] la tierra es un "mar de cuentas" y el agua forma ríos. Los lugares sin vida consciente, como el espacio profundo, apenas existen en este reino, lo que permite viajar entre mundos a través de él.
+
+* **Alias:** [[Shadesmar]] (en Roshar)
+
+### Reino Espiritual
+Es el reino de las almas, las identidades y las Conexiones. Es el plano del poder puro y la [[Investidura]], donde reside la esencia de las [[Esquirlas de Adonalsium]]. En el Reino Espiritual, la ubicación no es relevante; todo está interconectado en un único lugar.
+
+## Apariciones
+* [[Nacidos de la bruma: Historia Secreta]] (Explicado en detalle)
+* Mencionado o implícito en toda la saga del Cosmere.

--- a/Cosmere/50_Lore_y_Conceptos/Sombras_Cognitivas.md
+++ b/Cosmere/50_Lore_y_Conceptos/Sombras_Cognitivas.md
@@ -1,0 +1,24 @@
+---
+tags: concepto, cosmere
+alias: [Cognitive Shadow, Sombra Cognitiva]
+---
+
+# Sombras Cognitivas
+
+## Descripción General
+Una Sombra Cognitiva es la impresión que la mente de una persona deja en la [[Investidura]] después de su muerte física. Esencialmente, es un tipo de fantasma o espectro que puede retener la conciencia.
+
+## Mecánicas
+Cuando un ser fuertemente Investido muere, su mente (su Sombra Cognitiva) a veces puede persistir en el [[Reino Cognitivo]], negándose a pasar al Más Allá. Para ello, la Sombra debe aferrarse a una fuente de Investidura que la ancle y la mantenga.
+
+Si una Sombra Cognitiva puede encontrar una fuente de Investidura lo suficientemente grande, puede incluso recuperar una forma de cuerpo físico.
+
+## Ejemplos Notables
+* **[[Treno]]:** Los muertos a veces persisten como "umbras", unas Sombras Cognitivas que se sienten atraídas por la sangre, el fuego y los movimientos bruscos.
+* **[[Scadrial]]:** [[Kelsier]] se convierte en una Sombra Cognitiva tras su muerte, anclándose al [[Pozo de la Ascensión]].
+* **[[Roshar]]:** Los [[Heraldos]] son Sombras Cognitivas atadas al Juramento.
+
+## Apariciones
+* [[Arcanum Ilimitado]]
+* [[Nacidos de la bruma: Historia Secreta]]
+* Mencionado o implícito en toda la saga del Cosmere.


### PR DESCRIPTION
Se procesa el libro "Arcanum Ilimitado" y se integra en la base de conocimiento existente.

Se crean nuevas notas para los mundos, personajes y magias de Sel, Scadrial, Taldain, Treno y Primero del Sol. Se actualizan las notas existentes de Roshar con la información de "Danzante del Filo".

Se actualiza el registro de análisis.